### PR TITLE
Fix build on raspberry pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Tools for Raspberry
  - v4l2compress_omx : 
 
 >	read YUV from a V4L2 capture device, compress in H264 format using OMX and write to a V4L2 output device
+>   make sure the v4l2 source supports the correct pixel format. This can be configured for device 0 using `v4l2-ctl -d 0 -v width=640,height=480,pixelformat=YUYV -V`. Then check it was applied correctly using `v4l2-ctl --all`
 
 Build
 -----

--- a/src/v4l2compress_omx.cpp
+++ b/src/v4l2compress_omx.cpp
@@ -144,9 +144,9 @@ int main(int argc, char* argv[])
 				encode_config_activate(video_encode);		
 				
                                 // intermediate I420 image
-                                uint8 i420_p0[width*height];
-                                uint8 i420_p1[width*height/2];
-                                uint8 i420_p2[width*height/2];
+                                uint8_t i420_p0[width*height];
+                                uint8_t i420_p1[width*height/2];
+                                uint8_t i420_p2[width*height/2];
 				
 				timeval tv;
 				
@@ -174,7 +174,7 @@ int main(int argc, char* argv[])
 								}
 								else
 								{
-									libyuv::ConvertToI420((const uint8*)inbuffer, rsize,
+									libyuv::ConvertToI420((const uint8_t*)inbuffer, rsize,
 										i420_p0, width,
 										i420_p1, width/2,
 										i420_p2, width/2,
@@ -186,7 +186,7 @@ int main(int argc, char* argv[])
 									libyuv::ConvertFromI420(i420_p0, width,
 											i420_p1, width/2,
 											i420_p2, width/2,
-											(uint8*)buf->pBuffer, 0,
+											(uint8_t*)buf->pBuffer, 0,
 											width, height,
 											V4L2_PIX_FMT_YUV420);
 									buf->nFilledLen = width*height*3/2;

--- a/src/v4l2detect_yuv.cpp
+++ b/src/v4l2detect_yuv.cpp
@@ -139,10 +139,10 @@ int main(int argc, char* argv[])
 			else
 			{
 				// intermediate I420 image
-				uint8 i420[width*height*2];
-				uint8* i420_p0=i420;
-				uint8* i420_p1=&i420[width*height];
-				uint8* i420_p2=&i420[width*height*3/2];								
+				uint8_t i420[width*height*2];
+				uint8_t* i420_p0=i420;
+				uint8_t* i420_p1=&i420[width*height];
+				uint8_t* i420_p2=&i420[width*height*3/2];								
 				
 				timeval tv;
 				
@@ -164,7 +164,7 @@ int main(int argc, char* argv[])
 						}
 						else
 						{
-							libyuv::ConvertToI420((const uint8*)inbuffer, rsize,
+							libyuv::ConvertToI420((const uint8_t*)inbuffer, rsize,
 								i420_p0, width,
 								i420_p1, width/2,
 								i420_p2, width/2,
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
 							libyuv::ConvertFromI420(i420_p0, width,
 									i420_p1, width/2,
 									i420_p2, width/2,
-									(uint8*)outBuffer, 0,
+									(uint8_t*)outBuffer, 0,
 									width, height, 
 									outformat);
 							


### PR DESCRIPTION
## Description

v4l2compress_omx does not build on raspberry pi 1 (armv6). It cannot resolve the `uint8` type, the typedef is not defined in the raspbian buster `stdint.h`. If I change the type to `uint8_t` compilation works. 

I also needed to switch my video source pixel format to `YUYV` to make the compression work. My ov534 supports both RGB and YUV but by default the first one was selected.  It took me some time to figure that out. Perhaps this can be mentioned in README.

One question also, the framerate for the compress is set to 30fps fixed, while the default setting for the `v4l2rtspserver` is 25 frames. Would it make sense to add a CLI switch to set the compress framerate to align with the server? Or is there a reason why it's set to 30fps?

Also despite the HW acceleration the compression seems to take quite some CPU on the PI1, I might run a perf on it to see where exactly the time is lost, but my guess is that it might still be the internal YUV conversion for the codec.

## Motivation and Context
Compilation on raspberry pi 1 is broken. 
```
pi@raspberrypi:~/v4l2tools $ make
PREFIX=/usr
ARCH=armv6l
with jpeg
g++ -o v4l2detect_yuv -std=c++11 -W -Wall -pthread -g -pipe  -I include -I v4l2wrapper/inc -I /opt/vc/include/ -I /opt/vc/include/interface/vcos/ -I /opt/vc/include/interface/vcos/pthreads/ -I /opt/vc/include/interface/vmcs_host/linux/ -I /opt/vc/src/hello_pi/libs/ilclient  -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -U_FORTIFY_SOURCE -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT -ftree-vectorize -pipe -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM -Wno-psabi -DHAVE_JPEG src/v4l2detect_yuv.cpp libyuv.a libv4l2wrapper.a -L /opt/vc/lib -L /opt/vc/src/hello_pi/libs/ilclient -lpthread -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -ljpeg -lopencv_core -lopencv_objdetect -lopencv_imgproc -I libyuv/include
src/v4l2detect_yuv.cpp: In function ‘int main(int, char**)’:
src/v4l2detect_yuv.cpp:135:34: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
    if ( (videoOutput->getWidth() != width) || (videoOutput->getHeight() != height) )
          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
src/v4l2detect_yuv.cpp:135:73: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
    if ( (videoOutput->getWidth() != width) || (videoOutput->getHeight() != height) )
                                                ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
src/v4l2detect_yuv.cpp:142:5: error: ‘uint8’ was not declared in this scope
     uint8 i420[width*height*2];
     ^~~~~
src/v4l2detect_yuv.cpp:142:5: note: suggested alternative: ‘uint’
     uint8 i420[width*height*2];
     ^~~~~
     uint
src/v4l2detect_yuv.cpp:143:12: error: ‘i420_p0’ was not declared in this scope
     uint8* i420_p0=i420;
            ^~~~~~~
src/v4l2detect_yuv.cpp:143:20: error: ‘i420’ was not declared in this scope
     uint8* i420_p0=i420;
                    ^~~~
src/v4l2detect_yuv.cpp:144:12: error: ‘i420_p1’ was not declared in this scope
     uint8* i420_p1=&i420[width*height];
            ^~~~~~~
src/v4l2detect_yuv.cpp:145:12: error: ‘i420_p2’ was not declared in this scope
     uint8* i420_p2=&i420[width*height*3/2];
            ^~~~~~~
src/v4l2detect_yuv.cpp:167:37: error: ISO C++ forbids declaration of ‘type name’ with no type [-fpermissive]
        libyuv::ConvertToI420((const uint8*)inbuffer, rsize,
                                     ^~~~~
src/v4l2detect_yuv.cpp:167:31: error: expected primary-expression before ‘const’
        libyuv::ConvertToI420((const uint8*)inbuffer, rsize,
                               ^~~~~
src/v4l2detect_yuv.cpp:167:31: error: expected ‘)’ before ‘const’
        libyuv::ConvertToI420((const uint8*)inbuffer, rsize,
                              ~^~~~~
                               )
src/v4l2detect_yuv.cpp:181:17: error: expected primary-expression before ‘)’ token
          (uint8*)outBuffer, 0,
                 ^
src/v4l2detect_yuv.cpp:120:7: warning: unused variable ‘informat’ [-Wunused-variable]
   int informat =  videoCapture->getFormat();
       ^~~~~~~~
make: *** [Makefile:135: v4l2detect_yuv] Error 1
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
