### PR TITLE
CMakeLists: update min version to 3.10 for CMake >= 4.0 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 # set project name from current directory
 get_filename_component(BASENAME ${CMAKE_SOURCE_DIR} NAME)


### PR DESCRIPTION
Update minimum version of CMake to 3.10 for CMake >= 4.0 version support.

New CMake require 3.5 as the minimum version with that increased to 3.10 in the next CMake release.