### PR TITLE
V4L2DeviceParameters remove deprecated verbose parameter

### DIFF
--- a/src/v4l2compress.cpp
+++ b/src/v4l2compress.cpp
@@ -50,7 +50,7 @@ int convert(V4l2Capture* videoCapture, const std::string& out_devname, V4l2IoTyp
 	// init V4L2 output interface
 	int width = videoCapture->getWidth();
 	int height = videoCapture->getHeight();		
-	V4L2DeviceParameters outparam(out_devname.c_str(), outformat, width, height, 0, ioTypeOut, verbose);
+	V4L2DeviceParameters outparam(out_devname.c_str(), outformat, width, height, 0, ioTypeOut);
 	V4l2Output* videoOutput = V4l2Output::create(outparam);
 	if (videoOutput == NULL)
 	{	
@@ -206,7 +206,7 @@ int main(int argc, char* argv[])
 	initLogger(verbose);
 
 	// init V4L2 capture interface
-	V4L2DeviceParameters param(in_devname,0,0,0,0,ioTypeIn,verbose);
+	V4L2DeviceParameters param(in_devname,0,0,0,0,ioTypeIn);
 	V4l2Capture* videoCapture = V4l2Capture::create(param);
 	
 	int ret = 0;

--- a/src/v4l2compress_omx.cpp
+++ b/src/v4l2compress_omx.cpp
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
 	initLogger(verbose);
 
 	// init V4L2 capture interface
-	V4L2DeviceParameters param(in_devname, 0, 0, 0, 0, ioTypeIn, verbose, openflags);
+	V4L2DeviceParameters param(in_devname, 0, 0, 0, 0, ioTypeIn, openflags);
 	V4l2Capture* videoCapture = V4l2Capture::create(param);
 	
 	if (videoCapture == NULL)
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
 		int height = videoCapture->getHeight();	
 		
 		// init V4L2 output interface
-		V4L2DeviceParameters outparam(out_devname, V4L2_PIX_FMT_H264, width, height, 0, ioTypeOut, verbose, openflags);
+		V4L2DeviceParameters outparam(out_devname, V4L2_PIX_FMT_H264, width, height, 0, ioTypeOut, openflags);
 		V4l2Output* videoOutput = V4l2Output::create(outparam);
 		if (videoOutput == NULL)
 		{	

--- a/src/v4l2copy.cpp
+++ b/src/v4l2copy.cpp
@@ -83,7 +83,7 @@ int main(int argc, char* argv[])
 	initLogger(verbose);
 
 	// init V4L2 capture interface
-	V4L2DeviceParameters param(in_devname, 0, 0, 0, 0, ioTypeIn, verbose);
+	V4L2DeviceParameters param(in_devname, 0, 0, 0, 0, ioTypeIn);
 	V4l2Capture* videoCapture = V4l2Capture::create(param);
 	
 	if (videoCapture == NULL)
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
 	else
 	{
 		// init V4L2 output interface
-		V4L2DeviceParameters outparam(out_devname, videoCapture->getFormat(), videoCapture->getWidth(), videoCapture->getHeight(), 0, ioTypeOut, verbose);
+		V4L2DeviceParameters outparam(out_devname, videoCapture->getFormat(), videoCapture->getWidth(), videoCapture->getHeight(), 0, ioTypeOut);
 		V4l2Output* videoOutput = V4l2Output::create(outparam);
 		if (videoOutput == NULL)
 		{	

--- a/src/v4l2detect_yuv.cpp
+++ b/src/v4l2detect_yuv.cpp
@@ -108,7 +108,7 @@ int main(int argc, char* argv[])
 	initLogger(verbose);
 
 	// init V4L2 capture interface
-	V4L2DeviceParameters param(in_devname, v4l2_fourcc('Y', 'U', 'Y', 'V'), 640, 480, 0, ioTypeIn, verbose);
+	V4L2DeviceParameters param(in_devname, v4l2_fourcc('Y', 'U', 'Y', 'V'), 640, 480, 0, ioTypeIn);
 	V4l2Capture* videoCapture = V4l2Capture::create(param);
 	
 	if (videoCapture == NULL)
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
 				
 		// init V4L2 output interface
 		int outformat =  v4l2_fourcc('B', 'G', 'R', '3'); //v4l2_fourcc(outFormatStr[0],outFormatStr[1],outFormatStr[2],outFormatStr[3]);
-		V4L2DeviceParameters outparam(out_devname, outformat, videoCapture->getWidth(), videoCapture->getHeight(), 0, ioTypeOut, verbose);
+		V4L2DeviceParameters outparam(out_devname, outformat, videoCapture->getWidth(), videoCapture->getHeight(), 0, ioTypeOut);
 		V4l2Output* videoOutput = V4l2Output::create(outparam);
 		if (videoOutput == NULL)
 		{	

--- a/src/v4l2display_h264.cpp
+++ b/src/v4l2display_h264.cpp
@@ -237,7 +237,7 @@ int main (int argc, char **argv)
 		int port_settings_changed = 0;
 		int first_packet = 1;
 		
-		V4L2DeviceParameters param(in_devname,0,0,0,0,ioTypeIn,verbose);
+		V4L2DeviceParameters param(in_devname,0,0,0,0,ioTypeIn);
 		V4l2Capture* videoCapture = V4l2Capture::create(param);
 
 		if (videoCapture) {

--- a/src/v4l2dump.cpp
+++ b/src/v4l2dump.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
 	initLogger(verbose);
 
 	// init V4L2 capture interface
-	V4L2DeviceParameters param(in_devname, 0, 0, 0, 0, ioTypeIn, verbose);
+	V4L2DeviceParameters param(in_devname, 0, 0, 0, 0, ioTypeIn);
 	V4l2Capture* videoCapture = V4l2Capture::create(param);
 	
 	if (videoCapture == NULL)

--- a/src/v4l2grab_h264.cpp
+++ b/src/v4l2grab_h264.cpp
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
 	// initialize log4cpp
 	initLogger(verbose);
 	
-	V4L2DeviceParameters outparam(out_devname, V4L2_PIX_FMT_H264,  width, height, 0, ioTypeOut, verbose);
+	V4L2DeviceParameters outparam(out_devname, V4L2_PIX_FMT_H264,  width, height, 0, ioTypeOut);
 	V4l2Output* videoOutput = V4l2Output::create(outparam);
 	if (videoOutput == NULL)
 	{	

--- a/src/v4l2source_yuv.cpp
+++ b/src/v4l2source_yuv.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
 	initLogger(verbose);
 
 	// init V4L2 output interface
-	V4L2DeviceParameters outparam(out_devname, V4L2_PIX_FMT_YUYV, width, height, fps, ioTypeOut, verbose);
+	V4L2DeviceParameters outparam(out_devname, V4L2_PIX_FMT_YUYV, width, height, fps, ioTypeOut);
 	V4l2Output* videoOutput = V4l2Output::create(outparam);
 	if (videoOutput == NULL)
 	{	


### PR DESCRIPTION
## Description

With the deprecated verbose flag in place v4l2compress for example would only work if the parameter vv gets set.

## Related Issue

https://github.com/mpromonet/v4l2tools/issues/53

## Motivation and Context

Removing the verbose flag fixes the above mentioned behavior.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
